### PR TITLE
Add structured point tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# tennis-match-form
+# Tennis Match Form & Report Generator
+
+This is a Vite + React + Tailwind project to create tennis match reports.
+
+Points are tracked using pairs of lines:
+
+```
+0-0 Giacomo
+7,1,1,1
+0-1 Mattia
+@3,4,4,5
+```
+
+Each game is represented by a score and player line followed by a comma separated list of points.
+
+Run the development server:
+
+```bash
+npm install
+npm run dev
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tennis Match Form & Report Generator</title>
+  </head>
+  <body class="bg-gray-100 text-gray-800">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "tennis-match-form",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import MatchReportForm from './components/MatchReportForm'
+
+export default function App() {
+  return <MatchReportForm />
+}

--- a/src/components/MatchReportForm.jsx
+++ b/src/components/MatchReportForm.jsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useState } from 'react'
+import { validateScore, isNumeric, parsePoints } from '../utils/validation'
+import PreviewPanel from './PreviewPanel'
+
+const STORAGE_KEY = 'match-report-form'
+
+export default function MatchReportForm() {
+  const [form, setForm] = useState({
+    playerA: '',
+    playerB: '',
+    format: 'No-Ad',
+    score: '',
+    tiebreak: false,
+    pointsPlayed: '',
+    errorsA: '',
+    errorsB: '',
+    winnersA: '',
+    winnersB: '',
+    notes: '',
+    sendEmail: false,
+    previewOnly: false
+  })
+
+  const [errors, setErrors] = useState({})
+
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      setForm(JSON.parse(saved))
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(form))
+  }, [form])
+
+  const update = (field) => (e) => {
+    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value
+    setForm({ ...form, [field]: value })
+  }
+
+  const validate = () => {
+    const errs = {}
+    if (form.score && !validateScore(form.score)) {
+      errs.score = 'Invalid score format'
+    }
+    if (form.errorsA && !isNumeric(form.errorsA)) errs.errorsA = 'Must be numeric'
+    if (form.errorsB && !isNumeric(form.errorsB)) errs.errorsB = 'Must be numeric'
+    if (form.winnersA && !isNumeric(form.winnersA)) errs.winnersA = 'Must be numeric'
+    if (form.winnersB && !isNumeric(form.winnersB)) errs.winnersB = 'Must be numeric'
+    setErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!validate()) return
+    if (form.sendEmail) {
+      try {
+        await fetch('https://formspree.io/f/placeholder', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        })
+      } catch (err) {
+        console.error('Email failed', err)
+      }
+    }
+    alert('Form submitted!')
+  }
+
+  const data = {
+    ...form,
+    pointsPlayed: parsePoints(form.pointsPlayed)
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded shadow">
+        <h1 className="text-xl font-bold mb-4">Tennis Match Report</h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="relative">
+            <input value={form.playerA} onChange={update('playerA')} id="playerA" className="peer form-input w-full border rounded p-2" />
+            <label htmlFor="playerA" className="absolute text-sm text-gray-500 left-2 top-1 peer-focus:-top-3 peer-focus:text-xs transition-all">Player A</label>
+          </div>
+          <div className="relative">
+            <input value={form.playerB} onChange={update('playerB')} id="playerB" className="peer form-input w-full border rounded p-2" />
+            <label htmlFor="playerB" className="absolute text-sm text-gray-500 left-2 top-1 peer-focus:-top-3 peer-focus:text-xs transition-all">Player B</label>
+          </div>
+          <div>
+            <label className="block text-sm">Match Format</label>
+            <select value={form.format} onChange={update('format')} className="mt-1 w-full border rounded p-2">
+              <option>No-Ad</option>
+              <option>Advantage</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm">Score</label>
+            <input value={form.score} onChange={update('score')} className="w-full border rounded p-2" />
+            {errors.score && <p className="text-red-500 text-xs">{errors.score}</p>}
+          </div>
+          <div className="flex items-center">
+            <input type="checkbox" id="tiebreak" checked={form.tiebreak} onChange={update('tiebreak')} className="mr-2" />
+            <label htmlFor="tiebreak" className="text-sm">Tiebreak Present</label>
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm">Points Played (score & player line followed by points)</label>
+          <textarea
+            value={form.pointsPlayed}
+            onChange={update('pointsPlayed')}
+            rows="6"
+            className="w-full border rounded p-2"
+            placeholder={`0-0 Giacomo\n7,1,1,1\n0-1 Mattia\n@3,4,4,5`}
+          ></textarea>
+        </div>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div>
+            <label className="block text-sm">Errors A</label>
+            <input value={form.errorsA} onChange={update('errorsA')} className="w-full border rounded p-2" />
+            {errors.errorsA && <p className="text-red-500 text-xs">{errors.errorsA}</p>}
+          </div>
+          <div>
+            <label className="block text-sm">Errors B</label>
+            <input value={form.errorsB} onChange={update('errorsB')} className="w-full border rounded p-2" />
+            {errors.errorsB && <p className="text-red-500 text-xs">{errors.errorsB}</p>}
+          </div>
+          <div>
+            <label className="block text-sm">Winners A</label>
+            <input value={form.winnersA} onChange={update('winnersA')} className="w-full border rounded p-2" />
+            {errors.winnersA && <p className="text-red-500 text-xs">{errors.winnersA}</p>}
+          </div>
+          <div>
+            <label className="block text-sm">Winners B</label>
+            <input value={form.winnersB} onChange={update('winnersB')} className="w-full border rounded p-2" />
+            {errors.winnersB && <p className="text-red-500 text-xs">{errors.winnersB}</p>}
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm">Notes</label>
+          <textarea value={form.notes} onChange={update('notes')} rows="3" className="w-full border rounded p-2"></textarea>
+        </div>
+        <div className="flex space-x-4">
+          <label className="flex items-center text-sm"><input type="checkbox" checked={form.sendEmail} onChange={update('sendEmail')} className="mr-2" />Send via email</label>
+          <label className="flex items-center text-sm"><input type="checkbox" checked={form.previewOnly} onChange={update('previewOnly')} className="mr-2" />Preview only</label>
+        </div>
+        <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">Submit</button>
+      </form>
+      <PreviewPanel data={data} />
+      <footer className="text-center text-xs text-gray-500 mt-6">Created with React + Tailwind + Vite on Replit</footer>
+    </div>
+  )
+}

--- a/src/components/PreviewPanel.jsx
+++ b/src/components/PreviewPanel.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+export default function PreviewPanel({ data }) {
+  const copyJson = () => {
+    navigator.clipboard.writeText(JSON.stringify(data, null, 2))
+  }
+
+  const downloadJson = () => {
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(blob)
+    link.download = 'match-report.json'
+    link.click()
+  }
+
+  const totalGames = data.pointsPlayed?.length || 0
+  const totalPoints = data.pointsPlayed?.reduce((sum, g) => sum + g.points.length, 0) || 0
+  const winnerDiff = (parseInt(data.winnersA || 0) - parseInt(data.winnersB || 0))
+
+  return (
+    <div className="p-4 bg-white shadow rounded mt-4">
+      <pre className="overflow-auto text-sm bg-gray-100 p-2 rounded max-h-60">{JSON.stringify(data, null, 2)}</pre>
+      <div className="mt-2 space-y-1 text-sm">
+        <p>Total Games: {totalGames}</p>
+        <p>Total Points: {totalPoints}</p>
+        <p>Winner Difference: {winnerDiff}</p>
+      </div>
+      <div className="mt-3 flex gap-2">
+        <button onClick={copyJson} className="px-3 py-1 bg-blue-500 text-white rounded">Copy JSON to clipboard</button>
+        <button onClick={downloadJson} className="px-3 py-1 bg-green-500 text-white rounded">Download JSON file</button>
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply min-h-screen;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,34 @@
+export function validateScore(score) {
+  const pattern = /^(\d+[\u2013-]\d+)(\s+\d+[\u2013-]\d+)*$/
+  return pattern.test(score.trim())
+}
+
+export function isNumeric(value) {
+  return /^\d+$/.test(value)
+}
+
+export function parsePoints(text) {
+  const lines = text
+    .split(/\n+/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+  const result = []
+  for (let i = 0; i < lines.length; i += 2) {
+    const header = lines[i]
+    const pointsLine = lines[i + 1] || ''
+    if (!header) continue
+    const spaceIndex = header.indexOf(' ')
+    if (spaceIndex === -1) {
+      result.push({ score: header, player: '', points: [] })
+      continue
+    }
+    const score = header.slice(0, spaceIndex)
+    const player = header.slice(spaceIndex + 1)
+    const points = pointsLine
+      .split(',')
+      .map((p) => p.trim())
+      .filter(Boolean)
+    result.push({ score, player, points })
+  }
+  return result
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
## Summary
- parse points with score and player lines
- send parsed data in email
- show parsed stats in preview panel
- document the new points format

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400d63259883278fd1a22654dab4f8