### PR TITLE
Implement basic CLI for tennis tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# tennis-match-form
+# Tennis Tracker CLI
+
+This repository contains a minimal command-line implementation inspired by the **Tennis Tracker Pro** project.
+
+The goal of this small tool is to demonstrate how match data could be collected and managed before a full mobile application is built.
+
+## Features
+
+- Start a new match between two players.
+- Record points interactively via the terminal.
+- Automatic score calculation for games and sets.
+- Simple unit test demonstrating the score logic.
+
+## Getting Started
+
+Ensure you have Node.js installed. Run the following commands:
+
+```bash
+npm install       # (no dependencies, but sets up the project)
+npm test          # run unit test
+npm start         # launch interactive CLI
+```
+
+During a match, type the name of the point winner (`Player 1` or `Player 2`) and the score will update. Type `exit` to end the session.
+
+This is only a starting point for the larger vision described in the project prompt.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,29 @@
+import { TennisMatch } from './src/match.js';
+import readline from 'readline';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+function ask(query) {
+  return new Promise(resolve => rl.question(query, ans => resolve(ans)));
+}
+
+async function main() {
+  const player1 = await ask('Player 1 name: ');
+  const player2 = await ask('Player 2 name: ');
+  const match = new TennisMatch(player1, player2);
+  console.log(`Match start: ${player1} vs ${player2}`);
+  console.log('Enter point winner name (or exit):');
+  while (true) {
+    const ans = await ask('> ');
+    if (!ans || ans.toLowerCase() === 'exit') break;
+    const winner = ans.trim();
+    match.recordPoint(winner);
+    console.log(match.getScore());
+  }
+  rl.close();
+}
+
+main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "tennis-tracker-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tennis-tracker-cli",
+      "version": "0.1.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tennis-tracker-cli",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Simple CLI for tracking tennis matches",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node test.js"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/src/match.js
+++ b/src/match.js
@@ -1,0 +1,56 @@
+export class TennisMatch {
+  constructor(player1, player2, setsToWin = 2, gamesPerSet = 6) {
+    this.players = [player1, player2];
+    this.setsToWin = setsToWin;
+    this.gamesPerSet = gamesPerSet;
+    this.reset();
+  }
+
+  reset() {
+    this.currentSet = 0;
+    this.sets = [{ games: [0, 0], points: [0, 0] }];
+    this.winner = null;
+  }
+
+  pointValue(p) {
+    const values = [0, 15, 30, 40];
+    return values[p] || 'A';
+  }
+
+  recordPoint(winnerName) {
+    if (this.winner) return;
+    const w = this.players.indexOf(winnerName);
+    if (w === -1) return;
+    const l = 1 - w;
+    const set = this.sets[this.currentSet];
+    const points = set.points;
+    if (points[w] >= 3 && points[w] - points[l] >= 1) {
+      // wins game
+      points[0] = points[1] = 0;
+      set.games[w] += 1;
+      if (set.games[w] >= this.gamesPerSet && set.games[w] - set.games[l] >= 2) {
+        // wins set
+        this.currentSet += 1;
+        this.sets.push({ games: [0, 0], points: [0, 0] });
+        const setsWon = this.sets.reduce((acc, s) => acc + (s.games[w] > s.games[l] ? 1 : 0), 0);
+        if (setsWon >= this.setsToWin) {
+          this.winner = this.players[w];
+        }
+      }
+    } else {
+      points[w] += 1;
+    }
+  }
+
+  formatSet(set) {
+    return `${set.games[0]}-${set.games[1]}`;
+  }
+
+  getScore() {
+    const set = this.sets[this.currentSet];
+    const pointScore = `${this.pointValue(set.points[0])}-${this.pointValue(set.points[1])}`;
+    const setScores = this.sets.slice(0, this.currentSet).map(s => this.formatSet(s)).join(' ');
+    const current = `${setScores} [${pointScore}]`;
+    return this.winner ? `${this.winner} wins ${current}` : current;
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,11 @@
+import assert from 'assert';
+import { TennisMatch } from './src/match.js';
+
+const match = new TennisMatch('A', 'B');
+match.recordPoint('A');
+match.recordPoint('A');
+match.recordPoint('A');
+match.recordPoint('A'); // game
+assert.strictEqual(match.sets[0].games[0], 1);
+assert.strictEqual(match.sets[0].games[1], 0);
+console.log('Tests passed');


### PR DESCRIPTION
## Summary
- add minimal Node.js CLI skeleton
- track games and sets with a `TennisMatch` class
- include test verifying basic scoring
- document usage in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840cda921848327814398a546a9fac5