### PR TITLE
Add initial React+Vite tennis tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# tennis-match-form
+# Tennis Match Tracker
+
+This app is a simple tennis match scoring tracker built with React, TypeScript and Vite. All data is stored in localStorage.
+
+## Development
+
+Install dependencies (requires Node.js):
+
+```bash
+npm install
+```
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+The app will be available at `http://localhost:5173` by default.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tennis Match Tracker</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "tennis-match-tracker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import CreateMatchForm from './components/CreateMatchForm';
+import Scoreboard from './components/Scoreboard';
+import { MatchSettings, MatchState } from './types';
+import { useLocalStorage } from './hooks/useLocalStorage';
+
+export default function App() {
+  const [match, setMatch] = useLocalStorage<MatchState | null>('currentMatch', null);
+  const handleNewMatch = (settings: MatchSettings) => {
+    const newMatch: MatchState = {
+      settings,
+      points: [],
+      gamePoints: [0, 0],
+      games: [0, 0],
+      sets: [[0, 0]],
+      server: settings.startingServer,
+      tiebreakPoints: [0, 0],
+      inTiebreak: false,
+      complete: false,
+    };
+    setMatch(newMatch);
+  };
+
+  if (!match) {
+    return <CreateMatchForm onCreate={handleNewMatch} />;
+  }
+
+  return <Scoreboard match={match} onUpdate={setMatch} />;
+}

--- a/src/components/CreateMatchForm.tsx
+++ b/src/components/CreateMatchForm.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { MatchSettings } from '../types';
+
+type Props = {
+  onCreate: (settings: MatchSettings) => void;
+};
+
+export default function CreateMatchForm({ onCreate }: Props) {
+  const [playerA, setPlayerA] = useState('');
+  const [playerB, setPlayerB] = useState('');
+  const [noAd, setNoAd] = useState(false);
+  const [thirdSet, setThirdSet] = useState<'tiebreak10' | 'set' | 'none'>('tiebreak10');
+  const [startingServer, setStartingServer] = useState<'A' | 'B'>('A');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onCreate({ playerA, playerB, noAd, thirdSet, startingServer });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ padding: '1rem' }}>
+      <h1>New Match</h1>
+      <div>
+        <label>
+          Player A
+          <input value={playerA} onChange={(e) => setPlayerA(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Player B
+          <input value={playerB} onChange={(e) => setPlayerB(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          No-Ad
+          <input type="checkbox" checked={noAd} onChange={(e) => setNoAd(e.target.checked)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Third Set
+          <select value={thirdSet} onChange={(e) => setThirdSet(e.target.value as any)}>
+            <option value="tiebreak10">Match Tiebreak</option>
+            <option value="set">Normal Set</option>
+            <option value="none">Disabled</option>
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          Starting Server
+          <select value={startingServer} onChange={(e) => setStartingServer(e.target.value as any)}>
+            <option value="A">Player A</option>
+            <option value="B">Player B</option>
+          </select>
+        </label>
+      </div>
+      <button type="submit">Create Match</button>
+    </form>
+  );
+}

--- a/src/components/Scoreboard.tsx
+++ b/src/components/Scoreboard.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { MatchState, PointDetail } from '../types';
+
+interface Props {
+  match: MatchState;
+  onUpdate: (match: MatchState) => void;
+}
+
+const POINT_LABELS = ['0', '15', '30', '40', 'AD'];
+
+export default function Scoreboard({ match, onUpdate }: Props) {
+  const { settings } = match;
+
+  const addPoint = (winner: 'A' | 'B', detail: PointDetail) => {
+    if (match.complete) return;
+    const next = { ...match } as MatchState;
+    next.points = [...next.points, { winner, ...detail }];
+
+    if (next.inTiebreak) {
+      const idx = winner === 'A' ? 0 : 1;
+      next.tiebreakPoints[idx] += 1;
+      const target = settings.thirdSet === 'tiebreak10' && next.sets.length === 3 ? 10 : 7;
+      if (next.tiebreakPoints[idx] >= target &&
+          next.tiebreakPoints[idx] - next.tiebreakPoints[1 - idx] >= 2) {
+        // win tiebreak
+        next.games[idx] += 1;
+        next.sets[next.sets.length - 1][idx] += 1;
+        next.tiebreakPoints = [0, 0];
+        next.inTiebreak = false;
+        next.gamePoints = [0, 0];
+        checkSetOver(next);
+      }
+    } else {
+      const idx = winner === 'A' ? 0 : 1;
+      const opp = 1 - idx;
+      next.gamePoints[idx] += 1;
+
+      if (next.gamePoints[idx] >= 4 && next.gamePoints[idx] - next.gamePoints[opp] >= 2) {
+        next.games[idx] += 1;
+        next.sets[next.sets.length - 1][idx] += 1;
+        next.gamePoints = [0, 0];
+        checkSetOver(next);
+      } else if (settings.noAd && next.gamePoints[idx] === 4) {
+        next.games[idx] += 1;
+        next.sets[next.sets.length - 1][idx] += 1;
+        next.gamePoints = [0, 0];
+        checkSetOver(next);
+      }
+    }
+
+    next.server = next.server === 'A' ? 'B' : 'A';
+    onUpdate(next);
+  };
+
+  function checkSetOver(state: MatchState) {
+    const [aGames, bGames] = state.sets[state.sets.length - 1];
+    if (aGames >= 6 || bGames >= 6) {
+      if (Math.abs(aGames - bGames) >= 2) {
+        startNewSet(state);
+      } else if (aGames === 6 && bGames === 6) {
+        state.inTiebreak = true;
+      }
+    }
+  }
+
+  function startNewSet(state: MatchState) {
+    if (state.sets.length === 3 || (state.sets.length === 2 && settings.thirdSet === 'none')) {
+      state.complete = true;
+      return;
+    }
+    state.sets.push([0, 0]);
+  }
+
+  const recordPoint = (winner: 'A' | 'B') => {
+    const detail: PointDetail = { type: 'winner', rallyCount: 0, firstServeIn: true };
+    addPoint(winner, detail);
+  };
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>
+        {settings.playerA} vs {settings.playerB}
+      </h1>
+      {match.sets.map((set, idx) => (
+        <div key={idx}>
+          Set {idx + 1}: {set[0]} - {set[1]}
+        </div>
+      ))}
+      {!match.complete && (
+        <div>
+          <h2>Game: {POINT_LABELS[match.gamePoints[0]]} - {POINT_LABELS[match.gamePoints[1]]}</h2>
+          {match.inTiebreak && (
+            <p>Tiebreak: {match.tiebreakPoints[0]} - {match.tiebreakPoints[1]}</p>
+          )}
+          <p>Server: {match.server === 'A' ? settings.playerA : settings.playerB}</p>
+          <button onClick={() => recordPoint('A')}>Point {settings.playerA}</button>
+          <button onClick={() => recordPoint('B')}>Point {settings.playerB}</button>
+        </div>
+      )}
+      {match.complete && <h2>Match Finished</h2>}
+    </div>
+  );
+}

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react';
+
+export function useLocalStorage<T>(key: string, initial: T) {
+  const [value, setValue] = useState<T>(() => {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : initial;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,8 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+button {
+  cursor: pointer;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,30 @@
+export interface MatchSettings {
+  playerA: string;
+  playerB: string;
+  noAd: boolean;
+  thirdSet: 'tiebreak10' | 'set' | 'none';
+  startingServer: 'A' | 'B';
+}
+
+export interface PointDetail {
+  type: 'winner' | 'forced-error' | 'unforced-error' | 'ace' | 'double-fault';
+  rallyCount: number;
+  firstServeIn: boolean;
+}
+
+export interface Point extends PointDetail {
+  winner: 'A' | 'B';
+}
+
+export interface MatchState {
+  settings: MatchSettings;
+  points: Point[];
+  /** Current game points: 0=0,1=15,2=30,3=40,4=AD */
+  gamePoints: [number, number];
+  games: [number, number];
+  sets: [number, number][];
+  server: 'A' | 'B';
+  tiebreakPoints: [number, number];
+  inTiebreak: boolean;
+  complete: boolean;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "types": ["node"],
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a React+TypeScript Vite project
- store match data in localStorage
- implement a form to create a match
- implement a basic scoreboard that records points

## Testing
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eadeabca08327a7f3ee3898e9ee7b